### PR TITLE
chore: change some typos

### DIFF
--- a/file-redirection/file-redirection.sh
+++ b/file-redirection/file-redirection.sh
@@ -2,6 +2,6 @@
 # the descriptor for standard output is 1
 # STDOUT
 ls -a 1>file-outpt.txt
-# the descriptor for standard output is 2
+# the descriptor for standard error is 2
 # STDERR
 lsl -l 2>file.err


### PR DESCRIPTION
# what's done
1 remove typos - `standard output` to `standard error`